### PR TITLE
1x nasa ode f95

### DIFF
--- a/Fortran_CommonCode.vfproj
+++ b/Fortran_CommonCode.vfproj
@@ -70,6 +70,7 @@
 		<File RelativePath=".\NumericalMethods\mod_triband_matrix.f90"/></Filter>
 		<Filter Name="Physics">
 		<File RelativePath=".\Physics\mod_native_vectors.f90"/>
+		<File RelativePath=".\mod_rigid_bodies.f90"/>
 		<File RelativePath=".\Physics\mod_spatial_vectors.f90"/></Filter>
 		<File RelativePath=".\mod_common.f90"/>
 		<File RelativePath=".\mod_show_matrix.f90"/>

--- a/NASA/mod_nasa_ode.f90
+++ b/NASA/mod_nasa_ode.f90
@@ -15,26 +15,22 @@
     implicit none
     
     interface
-        subroutine r4_deriv_scalar(t,y,yp)
+        pure subroutine r8_deriv_scalar(t,y,yp)
         import
-        real ( kind = 4 ), intent(in) :: t
-        real ( kind = 4 ), intent(in) :: y
-        real ( kind = 4 ), intent(out):: yp
+        real ( kind = 8 ), intent(in) :: t
+        real ( kind = 8 ), intent(in) :: y
+        real ( kind = 8 ), intent(out):: yp
         end subroutine
-        subroutine r4_deriv_vector(t,n,y,yp)
+        
+        pure subroutine r4_deriv_vector(t,n,y,yp)
         import
         real   ( kind = 4 ), intent(in) :: t
         integer( kind = 4 ), intent(in) :: n
         real   ( kind = 4 ), intent(in) :: y(n)
         real   ( kind = 4 ), intent(out):: yp(n)
         end subroutine
-        subroutine r8_deriv_scalar(t,y,yp)
-        import
-        real ( kind = 8 ), intent(in) :: t
-        real ( kind = 8 ), intent(in) :: y
-        real ( kind = 8 ), intent(out):: yp
-        end subroutine
-        subroutine r8_deriv_vector(t,n,y,yp)
+        
+        pure subroutine r8_deriv_vector(t,n,y,yp)
         import
         real   ( kind = 8 ), intent(in) :: t
         integer( kind = 4 ), intent(in) :: n
@@ -46,7 +42,7 @@
     contains
     
 
-    subroutine rk4 ( t0, u0, dt, f, u )
+    pure subroutine rk4 ( t0, u0, dt, f, u )
 
     !*****************************************************************************80
     !
@@ -94,20 +90,20 @@
     !    estimate at time T0+DT.
     !
     implicit none
-
-    real ( kind = 8 ) dt
-    !external f
+    
+    real ( kind = 8 ) , intent(in) :: t0
+    real ( kind = 8 ) , intent(in) :: u0
+    real ( kind = 8 ) , intent(in) :: dt
     procedure(r8_deriv_scalar), pointer, intent(in) :: f
+    real ( kind = 8 ) , intent(out) :: u
+    
     real ( kind = 8 ) f0
     real ( kind = 8 ) f1
     real ( kind = 8 ) f2
     real ( kind = 8 ) f3
-    real ( kind = 8 ) t0
     real ( kind = 8 ) t1
     real ( kind = 8 ) t2
     real ( kind = 8 ) t3
-    real ( kind = 8 ) u
-    real ( kind = 8 ) u0
     real ( kind = 8 ) u1
     real ( kind = 8 ) u2
     real ( kind = 8 ) u3
@@ -134,7 +130,7 @@
 
     return
     end
-    subroutine rk4vec ( t0, m, u0, dt, f, u )
+    pure subroutine rk4vec ( t0, m, u0, dt, f, u )
 
     !*****************************************************************************80
     !
@@ -177,22 +173,22 @@
     !    estimate at time T0+DT.
     !
     implicit none
-
-    integer ( kind = 4 ) m
-
-    real ( kind = 8 ) dt
-    !external f
+    !subroutine rk4vec ( t0, m, u0, dt, f, u )
+    real ( kind = 8 ) , intent(in) :: t0
+    integer ( kind = 4 ) , intent(in) :: m
+    real ( kind = 8 ) , intent(in) :: u0(m)
+    real ( kind = 8 ) , intent(in) :: dt
     procedure(r8_deriv_vector), pointer, intent(in) :: f
+    real ( kind = 8 ) , intent(out) :: u(m)
+
+    
     real ( kind = 8 ) f0(m)
     real ( kind = 8 ) f1(m)
     real ( kind = 8 ) f2(m)
     real ( kind = 8 ) f3(m)
-    real ( kind = 8 ) t0
     real ( kind = 8 ) t1
     real ( kind = 8 ) t2
     real ( kind = 8 ) t3
-    real ( kind = 8 ) u(m)
-    real ( kind = 8 ) u0(m)
     real ( kind = 8 ) u1(m)
     real ( kind = 8 ) u2(m)
     real ( kind = 8 ) u3(m)
@@ -224,7 +220,7 @@
     return
     end
 
-    subroutine r4_fehl ( f, neqn, y, t, h, yp, f1, f2, f3, f4, f5, s )
+    pure subroutine r4_fehl ( f, neqn, y, t, h, yp, f1, f2, f3, f4, f5, s )
 
     !*****************************************************************************80
     !
@@ -300,22 +296,22 @@
     !    Output, real ( kind = 4 ) S(NEQN), the estimate of the solution at T+H.
     !
     implicit none
-
-    integer ( kind = 4 ) neqn
+    ! subroutine r4_fehl ( f, neqn, y, t, h, yp, f1, f2, f3, f4, f5, s )
+    procedure(r4_deriv_vector), pointer, intent(in) :: f
+    integer ( kind = 4 ) , intent(in) :: neqn
+    real ( kind = 4 ) , intent(in) :: y(neqn)
+    real ( kind = 4 ) , intent(in) :: t
+    real ( kind = 4 ) , intent(in) :: h
+    real ( kind = 4 ) , intent(in) :: yp(neqn)
+    real ( kind = 4 ) , intent(out) :: f1(neqn)
+    real ( kind = 4 ) , intent(out) :: f2(neqn)
+    real ( kind = 4 ) , intent(out) :: f3(neqn)
+    real ( kind = 4 ) , intent(out) :: f4(neqn)
+    real ( kind = 4 ) , intent(out) :: f5(neqn)
+    real ( kind = 4 ) , intent(out) :: s(neqn)
 
     real ( kind = 4 ) ch
     !external f
-    procedure(r4_deriv_vector), pointer, intent(in) :: f
-    real ( kind = 4 ) f1(neqn)
-    real ( kind = 4 ) f2(neqn)
-    real ( kind = 4 ) f3(neqn)
-    real ( kind = 4 ) f4(neqn)
-    real ( kind = 4 ) f5(neqn)
-    real ( kind = 4 ) h
-    real ( kind = 4 ) s(neqn)
-    real ( kind = 4 ) t
-    real ( kind = 4 ) y(neqn)
-    real ( kind = 4 ) yp(neqn)
 
     ch = h / 4.0E+00
 
@@ -373,7 +369,7 @@
 
     return
     end
-    subroutine r4_rkf45 ( f, neqn, y, yp, t, tout, relerr, abserr, flag )
+    pure subroutine r4_rkf45 ( f, neqn, y, yp, t, tout, relerr, abserr, flag, h)
 
     !*****************************************************************************80
     !
@@ -537,11 +533,18 @@
     !    addressed.
     !
     implicit none
+    
+    procedure(r4_deriv_vector), pointer, intent(in) :: f
+    integer ( kind = 4 ) , intent(in) :: neqn
+    real ( kind = 4 ) , intent(inout) :: y(neqn)
+    real ( kind = 4 ) , intent(inout) :: yp(neqn)
+    real ( kind = 4 ) , intent(inout) :: t
+    real ( kind = 4 ) , intent(in) :: tout
+    real ( kind = 4 ) , intent(inout) :: relerr
+    real ( kind = 4 ) , intent(in) :: abserr
+    integer ( kind = 4 ), intent(out) :: flag
+    real ( kind = 4 ), intent(out) :: h
 
-    integer ( kind = 4 ) neqn
-
-    real ( kind = 4 ) abserr
-    real ( kind = 4 ), save :: abserr_save = -1.0E+00
     real ( kind = 4 ) ae
     real ( kind = 4 ) dt
     real ( kind = 4 ) ee
@@ -549,39 +552,46 @@
     real ( kind = 4 ) eps
     real ( kind = 4 ) esttol
     real ( kind = 4 ) et
-    !external f
-    procedure(r4_deriv_vector), pointer, intent(in) :: f
+    
     real ( kind = 4 ) f1(neqn)
     real ( kind = 4 ) f2(neqn)
     real ( kind = 4 ) f3(neqn)
     real ( kind = 4 ) f4(neqn)
-    real ( kind = 4 ) f5(neqn)
-    real ( kind = 4 ), save :: h = -1.0E+00
-    logical hfaild
-    real ( kind = 4 ) hmin
-    integer ( kind = 4 ) flag
-    integer ( kind = 4 ), save :: flag_save = -1000
-    integer ( kind = 4 ), save :: init = -1000
-    integer ( kind = 4 ) k
-    integer ( kind = 4 ), save :: kflag = -1000
-    integer ( kind = 4 ), save :: kop = -1
-    integer ( kind = 4 ), parameter :: maxnfe = 3000
-    integer ( kind = 4 ) mflag
-    integer ( kind = 4 ), save :: nfe = -1
-    logical output
-    real ( kind = 4 ) relerr
-    real ( kind = 4 ) relerr_min
-    real ( kind = 4 ), save :: relerr_save = -1.0E+00
-    real ( kind = 4 ), parameter :: remin = 1.0E-12
+    real ( kind = 4 ) f5(neqn)    
     real ( kind = 4 ) s
     real ( kind = 4 ) scale
-    real ( kind = 4 ) t
     real ( kind = 4 ) tol
     real ( kind = 4 ) toln
-    real ( kind = 4 ) tout
-    real ( kind = 4 ) y(neqn)
-    real ( kind = 4 ) yp(neqn)
     real ( kind = 4 ) ypk
+    
+    integer ( kind = 4 ), parameter :: maxnfe = 3000
+    real ( kind = 4 ), parameter :: remin = 1.0E-12
+    
+    logical hfaild
+    real ( kind = 4 ) hmin
+    integer ( kind = 4 ) k
+    integer ( kind = 4 ) mflag
+    logical output
+    real ( kind = 4 ) relerr_min
+    real ( kind = 4 ) :: relerr_save 
+    real ( kind = 4 ) :: abserr_save 
+    integer ( kind = 4 ) :: flag_save 
+    integer ( kind = 4 ) :: init 
+    integer ( kind = 4 ) :: kflag 
+    integer ( kind = 4 ) :: kop 
+    integer ( kind = 4 ) :: nfe 
+    !
+    ! Default Vaalues
+    !
+    h = -1.0E+00
+    relerr_save = -1.0E+00
+    abserr_save = -1.0E+00
+    flag_save = -1000
+    init = -1000
+    kflag = -1000
+    kop = -1
+    nfe = -1
+    
     !
     !  Check the input parameters.
     !
@@ -635,23 +645,32 @@
 
             else if ( kflag == 5 .and. abserr == 0.0E+00 ) then
 
-                write ( *, '(a)' ) ' '
-                write ( *, '(a)' ) 'R4_RKF45 - Fatal error!'
-                write ( *, '(a)' ) '  KFLAG = 5 and ABSERR = 0.0'
-                stop
+                error stop ' '//NEW_LINE('a') & 
+                    //'R4_RKF45 - Fatal error!'//NEW_LINE('a') & 
+                    //'  KFLAG = 5 and ABSERR = 0.0'//NEW_LINE('a') 
+                
+                !write ( *, '(a)' ) ' '
+                !write ( *, '(a)' ) 'R4_RKF45 - Fatal error!'
+                !write ( *, '(a)' ) '  KFLAG = 5 and ABSERR = 0.0'
+                !stop
 
             else if ( &
                 kflag == 6 .and. &
                 relerr <= relerr_save .and. &
                 abserr <= abserr_save ) then
 
-                write ( *, '(a)' ) ' '
-                write ( *, '(a)' ) 'R4_RKF45 - Fatal error!'
-                write ( *, '(a)' ) '  KFLAG = 6 and'
-                write ( *, '(a)' ) '  RELERR <= RELERR_SAVE and'
-                write ( *, '(a)' ) '  ABSERR <= ABSERR_SAVE'
-
-                stop
+                error stop ' '//NEW_LINE('a') & 
+                    //'R4_RKF45 - Fatal error!'//NEW_LINE('a') & 
+                    //'  KFLAG = 6 and'//NEW_LINE('a') & 
+                    //'  RELERR <= RELERR_SAVE and'//NEW_LINE('a') & 
+                    //'  ABSERR <= ABSERR_SAVE'//NEW_LINE('a') 
+                
+                !write ( *, '(a)' ) ' '
+                !write ( *, '(a)' ) 'R4_RKF45 - Fatal error!'
+                !write ( *, '(a)' ) '  KFLAG = 6 and'
+                !write ( *, '(a)' ) '  RELERR <= RELERR_SAVE and'
+                !write ( *, '(a)' ) '  ABSERR <= ABSERR_SAVE'
+                !stop
 
             end if
             !
@@ -685,12 +704,19 @@
                 !  the instructions pertaining to FLAG = 5, 6, 7 or 8.
                 !
             else
-                write ( *, '(a)' ) ' '
-                write ( *, '(a)' ) 'R4_RKF45 - Fatal error!'
-                write ( *, '(a)' ) '  Integration cannot be continued.'
-                write ( *, '(a)' ) '  The user did not respond to the output'
-                write ( *, '(a)' ) '  value FLAG = 5, 6, 7, or 8.'
-                stop
+                
+                error stop ' '//NEW_LINE('a') & 
+                    //'R4_RKF45 - Fatal error!'//NEW_LINE('a') & 
+                    //'  Integration cannot be continued.'//NEW_LINE('a') & 
+                    //'  The user did not respond to the output'//NEW_LINE('a') & 
+                    //'  value FLAG = 5, 6, 7, or 8.'//NEW_LINE('a') 
+                
+                !write ( *, '(a)' ) ' '
+                !write ( *, '(a)' ) 'R4_RKF45 - Fatal error!'
+                !write ( *, '(a)' ) '  Integration cannot be continued.'
+                !write ( *, '(a)' ) '  The user did not respond to the output'
+                !write ( *, '(a)' ) '  value FLAG = 5, 6, 7, or 8.'
+                !stop
             end if
 
         end if
@@ -989,7 +1015,7 @@
 
     return
     end
-    subroutine r8_fehl ( f, neqn, y, t, h, yp, f1, f2, f3, f4, f5, s )
+    pure subroutine r8_fehl ( f, neqn, y, t, h, yp, f1, f2, f3, f4, f5, s )
 
     !*****************************************************************************80
     !
@@ -1065,22 +1091,22 @@
     !    Output, real ( kind = 8 ) S(NEQN), the estimate of the solution at T+H.
     !
     implicit none
-
-    integer ( kind = 4 ) neqn
+    ! subroutine r8_fehl ( f, neqn, y, t, h, yp, f1, f2, f3, f4, f5, s )
+    procedure(r8_deriv_vector), pointer, intent(in) :: f
+    integer ( kind = 4 ), intent(in) :: neqn
+    real ( kind = 8 ) , intent(in) :: y(neqn)
+    real ( kind = 8 ) , intent(in) :: t
+    real ( kind = 8 ) , intent(in) ::  h
+    real ( kind = 8 ) , intent(in) :: yp(neqn)
 
     real ( kind = 8 ) ch
     !external f
-    procedure(r8_deriv_vector), pointer, intent(in) :: f
-    real ( kind = 8 ) f1(neqn)
-    real ( kind = 8 ) f2(neqn)
-    real ( kind = 8 ) f3(neqn)
-    real ( kind = 8 ) f4(neqn)
-    real ( kind = 8 ) f5(neqn)
-    real ( kind = 8 ) h
-    real ( kind = 8 ) s(neqn)
-    real ( kind = 8 ) t
-    real ( kind = 8 ) y(neqn)
-    real ( kind = 8 ) yp(neqn)
+    real ( kind = 8 ) , intent(out) :: f1(neqn)
+    real ( kind = 8 ) , intent(out) :: f2(neqn)
+    real ( kind = 8 ) , intent(out) :: f3(neqn)
+    real ( kind = 8 ) , intent(out) :: f4(neqn)
+    real ( kind = 8 ) , intent(out) :: f5(neqn)
+    real ( kind = 8 ) , intent(out) :: s(neqn)
 
     ch = h / 4.0D+00
 
@@ -1138,7 +1164,7 @@
 
     return
     end
-    subroutine r8_rkf45 ( f, neqn, y, yp, t, tout, relerr, abserr, flag )
+    pure subroutine r8_rkf45 ( f, neqn, y, yp, t, tout, relerr, abserr, flag, h )
 
     !*****************************************************************************80
     !
@@ -1302,11 +1328,23 @@
     !    be addressed.
     !
     implicit none
-
-    integer ( kind = 4 ) neqn
-
-    real ( kind = 8 ) abserr
-    real ( kind = 8 ), save :: abserr_save = -1.0D+00
+    
+    procedure(r8_deriv_vector), pointer, intent(in) :: f
+    integer ( kind = 4 ), intent(in) :: neqn
+    real ( kind = 8 ), intent(inout) ::  t
+    real ( kind = 8 ), intent(inout) ::  y(neqn)
+    real ( kind = 8 ), intent(inout) ::  yp(neqn)
+    real ( kind = 8 ), intent(in) ::  tout
+    real ( kind = 8 ), intent(inout) ::  relerr
+    real ( kind = 8 ), intent(in) ::  abserr
+    integer ( kind = 4 ), intent(inout) :: flag
+    real ( kind = 8 ), intent(out) :: h
+    
+    integer ( kind = 4 ), parameter :: maxnfe = 3000
+    real ( kind = 8 ), parameter :: remin = 1.0E-12
+    
+    real ( kind = 8 ) :: relerr_save 
+    real ( kind = 8 ) :: abserr_save 
     real ( kind = 8 ) ae
     real ( kind = 8 ) dt
     real ( kind = 8 ) ee
@@ -1314,39 +1352,39 @@
     real ( kind = 8 ) eps
     real ( kind = 8 ) esttol
     real ( kind = 8 ) et
-    !external f
-    procedure(r8_deriv_vector), pointer, intent(in) :: f
     real ( kind = 8 ) f1(neqn)
     real ( kind = 8 ) f2(neqn)
     real ( kind = 8 ) f3(neqn)
     real ( kind = 8 ) f4(neqn)
     real ( kind = 8 ) f5(neqn)
-    real ( kind = 8 ), save :: h = -1.0D+00
     logical hfaild
     real ( kind = 8 ) hmin
-    integer ( kind = 4 ) flag
-    integer ( kind = 4 ), save :: flag_save = -1000
-    integer ( kind = 4 ), save :: init = -1000
     integer ( kind = 4 ) k
-    integer ( kind = 4 ), save :: kflag = -1000
-    integer ( kind = 4 ), save :: kop = -1
-    integer ( kind = 4 ), parameter :: maxnfe = 3000
     integer ( kind = 4 ) mflag
-    integer ( kind = 4 ), save :: nfe = -1
+    integer ( kind = 4 ) :: flag_save 
+    integer ( kind = 4 ) :: init 
+    integer ( kind = 4 ) :: kflag 
+    integer ( kind = 4 ) :: kop 
+    integer ( kind = 4 ) :: nfe 
     logical output
-    real ( kind = 8 ) relerr
     real ( kind = 8 ) relerr_min
-    real ( kind = 8 ), save :: relerr_save = -1.0D+00
-    real ( kind = 8 ), parameter :: remin = 1.0E-12
     real ( kind = 8 ) s
     real ( kind = 8 ) scale
-    real ( kind = 8 ) t
     real ( kind = 8 ) tol
     real ( kind = 8 ) toln
-    real ( kind = 8 ) tout
-    real ( kind = 8 ) y(neqn)
-    real ( kind = 8 ) yp(neqn)
     real ( kind = 8 ) ypk
+    !
+    ! Default Values
+    !
+    h = -1.0D+00
+    relerr_save = -1.0D+00
+    abserr_save = -1.0D+00
+    flag_save = -1000
+    init = -1000
+    kflag = -1000
+    kop = -1
+    nfe = -1
+    
     !
     !  Check the input parameters.
     !
@@ -1400,23 +1438,32 @@
 
             else if ( kflag == 5 .and. abserr == 0.0D+00 ) then
 
-                write ( *, '(a)' ) ' '
-                write ( *, '(a)' ) 'R8_RKF45 - Fatal error!'
-                write ( *, '(a)' ) '  KFLAG = 5 and ABSERR = 0.0'
-                stop
+                error stop ' '//NEW_LINE('a') & 
+                    //'R8_RKF45 - Fatal error!'//NEW_LINE('a') & 
+                    //'  KFLAG = 5 and ABSERR = 0.0'//NEW_LINE('a')
+                
+                !write ( *, '(a)' ) ' '
+                !write ( *, '(a)' ) 'R8_RKF45 - Fatal error!'
+                !write ( *, '(a)' ) '  KFLAG = 5 and ABSERR = 0.0'
+                !stop
 
             else if ( &
                 kflag == 6 .and. &
                 relerr <= relerr_save .and. &
                 abserr <= abserr_save ) then
 
-                write ( *, '(a)' ) ' '
-                write ( *, '(a)' ) 'R8_RKF45 - Fatal error!'
-                write ( *, '(a)' ) '  KFLAG = 6 and'
-                write ( *, '(a)' ) '  RELERR <= RELERR_SAVE and'
-                write ( *, '(a)' ) '  ABSERR <= ABSERR_SAVE'
-
-                stop
+                error stop ' '//NEW_LINE('a') & 
+                    //'R8_RKF45 - Fatal error!'//NEW_LINE('a') & 
+                    //'  KFLAG = 6 and'//NEW_LINE('a') & 
+                    //'  RELERR <= RELERR_SAVE and'//NEW_LINE('a') & 
+                    //'  ABSERR <= ABSERR_SAVE'//NEW_LINE('a') 
+                
+                !write ( *, '(a)' ) ' '
+                !write ( *, '(a)' ) 'R8_RKF45 - Fatal error!'
+                !write ( *, '(a)' ) '  KFLAG = 6 and'
+                !write ( *, '(a)' ) '  RELERR <= RELERR_SAVE and'
+                !write ( *, '(a)' ) '  ABSERR <= ABSERR_SAVE'
+                !stop
 
             end if
             !
@@ -1450,12 +1497,19 @@
                 !  the instructions pertaining to FLAG = 5, 6, 7 or 8.
                 !
             else
-                write ( *, '(a)' ) ' '
-                write ( *, '(a)' ) 'R8_RKF45 - Fatal error!'
-                write ( *, '(a)' ) '  Integration cannot be continued.'
-                write ( *, '(a)' ) '  The user did not respond to the output'
-                write ( *, '(a)' ) '  value FLAG = 5, 6, 7, or 8.'
-                stop
+                
+                error stop ' '//NEW_LINE('a') & 
+                    //'R8_RKF45 - Fatal error!'//NEW_LINE('a') & 
+                    //'  Integration cannot be continued.'//NEW_LINE('a') & 
+                    //'  The user did not respond to the output'//NEW_LINE('a') & 
+                    //'  value FLAG = 5, 6, 7, or 8.'//NEW_LINE('a') 
+                
+                !write ( *, '(a)' ) ' '
+                !write ( *, '(a)' ) 'R8_RKF45 - Fatal error!'
+                !write ( *, '(a)' ) '  Integration cannot be continued.'
+                !write ( *, '(a)' ) '  The user did not respond to the output'
+                !write ( *, '(a)' ) '  value FLAG = 5, 6, 7, or 8.'
+                !stop
             end if
 
         end if
@@ -1814,6 +1868,7 @@
     real ( kind = 4 ) t_stop
     real ( kind = 4 ) y(neqn)
     real ( kind = 4 ) yp(neqn)
+    real ( kind = 4 ) h
 
     write ( *, '(a)' ) ' '
     write ( *, '(a)' ) 'TEST01'
@@ -1852,7 +1907,7 @@
             + real (          i_step, kind = 4 ) * t_stop ) &
             / real ( n_step,          kind = 4 )
 
-        call r4_rkf45 ( r4_f1, neqn, y, yp, t, t_out, relerr, abserr, flag )
+        call r4_rkf45 ( r4_f1, neqn, y, yp, t, t_out, relerr, abserr, flag, h)
 
         write ( *, '(i4,2x,5g14.6)' ) flag, t, y(1), yp(1), r4_y1x ( t ), &
             y(1) - r4_y1x ( t )
@@ -1894,6 +1949,7 @@
     real ( kind = 4 ) t_stop
     real ( kind = 4 ) y(neqn)
     real ( kind = 4 ) yp(neqn)
+    real ( kind = 4 ) h
 
     write ( *, '(a)' ) ' '
     write ( *, '(a)' ) 'TEST02'
@@ -1939,7 +1995,7 @@
             + real (          i_step, kind = 4 ) * t_stop ) &
             / real ( n_step,          kind = 4 )
 
-        call r4_rkf45 ( r4_f2, neqn, y, yp, t, t_out, relerr, abserr, flag )
+        call r4_rkf45 ( r4_f2, neqn, y, yp, t, t_out, relerr, abserr, flag, h )
 
         write ( *, '(i4,2x,4g14.6)' ) flag, t, y(1), y(2)
 
@@ -1980,6 +2036,7 @@
     real ( kind = 4 ) t_stop
     real ( kind = 4 ) y(neqn)
     real ( kind = 4 ) yp(neqn)
+    real ( kind = 4 ) h
 
     write ( *, '(a)' ) ' '
     write ( *, '(a)' ) 'TEST03'
@@ -2026,7 +2083,7 @@
         !
         do while ( flag < 0 )
 
-            call r4_rkf45 ( r4_f1, neqn, y, yp, t, t_out, relerr, abserr, flag )
+            call r4_rkf45 ( r4_f1, neqn, y, yp, t, t_out, relerr, abserr, flag, h )
 
             write ( *, '(i4,2x,5g14.6)' ) flag, t, y(1), yp(1), r4_y1x ( t ), &
                 y(1) - r4_y1x ( t )
@@ -2064,10 +2121,10 @@
 
     integer ( kind = 4 ), parameter :: neqn = 1
 
-    real ( kind = 8 ) abserr
     integer ( kind = 4 ) flag
     integer ( kind = 4 ) i_step
     integer ( kind = 4 ) n_step
+    real ( kind = 8 ) abserr
     real ( kind = 8 ) relerr
     real ( kind = 8 ) t
     real ( kind = 8 ) t_out
@@ -2075,6 +2132,7 @@
     real ( kind = 8 ) t_stop
     real ( kind = 8 ) y(neqn)
     real ( kind = 8 ) yp(neqn)
+    real ( kind = 8 ) h
 
     write ( *, '(a)' ) ' '
     write ( *, '(a)' ) 'TEST04'
@@ -2113,7 +2171,7 @@
             + real (          i_step, kind = 8 ) * t_stop ) &
             / real ( n_step,          kind = 8 )
 
-        call r8_rkf45 ( r8_f1, neqn, y, yp, t, t_out, relerr, abserr, flag )
+        call r8_rkf45 ( r8_f1, neqn, y, yp, t, t_out, relerr, abserr, flag, h )
 
         write ( *, '(i4,2x,5g14.6)' ) flag, t, y(1), yp(1), r8_y1x ( t ), &
             y(1) - r8_y1x ( t )
@@ -2155,6 +2213,7 @@
     real ( kind = 8 ) t_stop
     real ( kind = 8 ) y(neqn)
     real ( kind = 8 ) yp(neqn)
+    real ( kind = 8 ) h
 
     write ( *, '(a)' ) ' '
     write ( *, '(a)' ) 'TEST05'
@@ -2195,7 +2254,7 @@
             + real (          i_step, kind = 8 ) * t_stop ) &
             / real ( n_step,          kind = 8 )
 
-        call r8_rkf45 ( r8_f2, neqn, y, yp, t, t_out, relerr, abserr, flag )
+        call r8_rkf45 ( r8_f2, neqn, y, yp, t, t_out, relerr, abserr, flag, h )
 
         write ( *, '(i4,2x,4g14.6)' ) flag, t, y(1), y(2)
 
@@ -2236,6 +2295,7 @@
     real ( kind = 8 ) t_stop
     real ( kind = 8 ) y(neqn)
     real ( kind = 8 ) yp(neqn)
+    real ( kind = 8 ) h
 
     write ( *, '(a)' ) ' '
     write ( *, '(a)' ) 'TEST06'
@@ -2282,7 +2342,7 @@
         !
         do while ( flag < 0 )
 
-            call r8_rkf45 ( r8_f1, neqn, y, yp, t, t_out, relerr, abserr, flag )
+            call r8_rkf45 ( r8_f1, neqn, y, yp, t, t_out, relerr, abserr, flag, h )
 
             write ( *, '(i4,2x,5g14.6)' ) flag, t, y(1), yp(1), r8_y1x ( t ), &
                 y(1) - r8_y1x ( t )
@@ -2298,7 +2358,7 @@
 
     return
     end
-    subroutine r4_f1 ( t, n, y, yp )
+    pure subroutine r4_f1 ( t, n, y, yp )
 
     !*****************************************************************************80
     !
@@ -2337,7 +2397,7 @@
     return
     end
     
-    function r4_y1x ( t )
+    pure function r4_y1x ( t )
 
     !*****************************************************************************80
     !
@@ -2363,14 +2423,14 @@
     !
     implicit none
 
-    real ( kind = 4 ) t
-    real ( kind = 4 ) r4_y1x
+    real ( kind = 4 ), intent(in) :: t
+    real ( kind = 4 ) :: r4_y1x
 
     r4_y1x = 20.0E+00 / ( 1.0E+00 + 19.0E+00 * exp ( - 0.25E+00 * t ) )
 
     return
     end
-    subroutine r4_f2 ( t, n, y, yp )
+    pure subroutine r4_f2 ( t, n, y, yp )
 
     !*****************************************************************************80
     !
@@ -2409,7 +2469,7 @@
 
     return
     end
-    subroutine r8_f1 ( t, n, y, yp )
+    pure subroutine r8_f1 ( t, n, y, yp )
 
     !*****************************************************************************80
     !
@@ -2448,7 +2508,7 @@
     return
     end
     
-    function r8_y1x ( t )
+    pure function r8_y1x ( t )
 
     !*****************************************************************************80
     !
@@ -2481,7 +2541,7 @@
 
     return
     end
-    subroutine r8_f2 ( t, n, y, yp )
+    pure subroutine r8_f2 ( t, n, y, yp )
 
     !*****************************************************************************80
     !

--- a/NASA/mod_nasa_quat.f90
+++ b/NASA/mod_nasa_quat.f90
@@ -1,4 +1,6 @@
     module mod_nasa_quat
+    
+    real ( kind = 8 ), parameter :: r8_pi = 3.141592653589793D+00
 
     contains
 
@@ -31,7 +33,6 @@
 
     real ( kind = 8 ) angle_deg
     real ( kind = 8 ) degrees_to_radians
-    real ( kind = 8 ), parameter :: r8_pi = 3.141592653589793D+00
 
     degrees_to_radians = ( angle_deg / 180.0D+00 ) * r8_pi
 
@@ -369,7 +370,7 @@
     integer ( kind = 4 ) seed
     real ( kind = 8 ) q(4)
     real ( kind = 8 ) r(4)
-    real ( kind = 8 ), parameter :: r8_pi = 3.141592653589793D+00
+    
 
     call r8vec_uniform_01 ( 4, seed, r )
 
@@ -775,7 +776,6 @@
     implicit none
 
     real ( kind = 8 ) angle_rad
-    real ( kind = 8 ), parameter :: r8_pi = 3.141592653589793D+00
     real ( kind = 8 ) radians_to_degrees
 
     radians_to_degrees = ( angle_rad / r8_pi ) * 180.0D+00

--- a/Physics/mod_native_vectors.f90
+++ b/Physics/mod_native_vectors.f90
@@ -188,13 +188,7 @@
             a(2), -a(1), 0._wp], [3,3])
         
     end function
-    
-    pure function quat_cross_product(a,b) result(c)
-    real(wp),  intent(in) :: a(4), b(4)
-    real(wp) ::  c(4)
-        c = [ 0._wp, vector_cross_product(a(2:4), b(2:4)) ]
-    end function
-    
+        
     function vector_mmoi_matrix(a) result(c)
     real(wp),  intent(in) :: a(3)
     real(wp) ::  c(3,3)
@@ -363,13 +357,17 @@
     real(wp) ::  s, c, axis(3), R(3,3), ax(3,3), axax(3,3)
         c = q(1)
         s = norm2(q(2:4))
-        axis = q(2:4)/s
-        ax = cross(axis)
-        axax = matmul(ax,ax)
-        if( present(inv) .and. inv) then
-            s = -s
+        if( s>0.0_wp) then
+            axis = q(2:4)/s
+            ax = cross(axis)
+            axax = matmul(ax,ax)
+            if( present(inv) .and. inv) then
+                s = -s
+            end if
+            R = eye_ + s*ax + (1-c)*axax        
+        else
+            R = eye_
         end if
-        R = eye_ + s*ax + (1-c)*axax        
     end function
     
     pure function quat_rot_vector(q, v, inv) result(r)
@@ -388,10 +386,45 @@
     end function
     
     pure function quat_conjugate(q) result(p)
-    real(wp),  intent(in) :: q(4)
+    real(wp), intent(in) :: q(4)
     real(wp) :: p(4)
         p = [ q(1), -q(2), -q(3), -q(4) ]
     end function
+    
+    pure function quat_product(q_1,q_2) result(p)
+    real(wp), intent(in) :: q_1(4), q_2(4)
+    real(wp) :: p(4), s_1, s_2, v_1(3), v_2(3)
+        s_1 = q_1(1)
+        s_2 = q_2(1)
+        v_1 = q_1(2:4)
+        v_2 = q_2(2:4)
+        
+        p = [s_1*s_2 - dot_product(v_1,v_2), &
+            s_1*v_2 + s_2*v_1 + cross(v_1,v_2)]
+        
+    end function
+    
+    pure function quat_cross_product(q_1,q_2) result(p)
+    real(wp), intent(in) :: q_1(4), q_2(4)
+    real(wp) :: p(4), v_1(3), v_2(3)
+        v_1 = q_1(2:4)
+        v_2 = q_2(2:4)        
+        p = [0.0_wp, &
+            cross(v_1,v_2)]        
+    end function
+
+    pure function quat_dot_product(q_1,q_2) result(p)
+    real(wp), intent(in) :: q_1(4), q_2(4)
+    real(wp) :: p, s_1, s_2, v_1(3), v_2(3)
+        s_1 = q_1(1)
+        s_2 = q_2(1)
+        v_1 = q_1(2:4)
+        v_2 = q_2(2:4)
+        
+        p = s_1*s_2 + dot_product(v_1,v_2)
+        
+    end function
+
     
     pure function quat_inv(q) result(p)
     real(wp),  intent(in) :: q(4)

--- a/mod_rigid_bodies.f90
+++ b/mod_rigid_bodies.f90
@@ -1,0 +1,290 @@
+    module mod_rigid_bodies
+    use mod_native_vectors
+    
+    integer, parameter :: n_dims=3, n_state=13
+    
+    type :: rigid_body
+        real(wp) :: mass
+        real(wp) :: mmoi(3)
+        real(wp) :: cg(3)
+    contains
+        procedure :: get_mmoi => rb_get_mmoi_state
+        procedure :: get_motion => rb_get_motion
+        procedure :: get_kin_energy => rb_get_kin_energy
+    end type
+    
+    
+    contains
+    
+    pure function rb_ellipsoid(mass, dx,dy,dz, cg) result(rb)
+    type(rigid_body) :: rb
+    real(wp), intent(in) :: mass, dx,dy,dz
+    real(wp), optional, intent(in) :: cg(3)
+    real(wp), parameter :: f= 1.0_wp/10
+    
+        rb%mass = mass
+        if(present(cg)) then
+            rb%cg = cg
+        else
+            rb%cg = o_
+        end if
+        
+        rb%mmoi = f*mass*[ (dy**2+dz**2), (dz**2+dx**2), (dx**2+dy**2)]
+    
+    end function
+    
+    pure function rb_box(mass, dx,dy,dz, cg) result(rb)
+    type(rigid_body) :: rb
+    real(wp), intent(in) :: mass, dx,dy,dz
+    real(wp), optional, intent(in) :: cg(3)
+    real(wp), parameter :: f= 1.0_wp/12
+    
+        rb%mass = mass
+        if(present(cg)) then
+            rb%cg = cg
+        else
+            rb%cg = o_
+        end if
+        
+        rb%mmoi = f*mass*[ (dy**2+dz**2), (dz**2+dx**2), (dx**2+dy**2)]
+    
+    end function
+    
+    pure function rb_cylinder(mass, diameter, height, cg) result(rb)
+    type(rigid_body) :: rb
+    real(wp), intent(in) :: mass, diameter, height
+    real(wp), optional, intent(in) :: cg(3)
+    real(wp), parameter :: fh= 1.0_wp/10, fd=1.0_wp/16
+    
+        rb%mass = mass
+        if(present(cg)) then
+            rb%cg = cg
+        else
+            rb%cg = o_
+        end if
+        
+        rb%mmoi = mass*[ fh*height**2 + fd*diameter**2, fh*height**2 + fd*diameter**2, 2*fd*diameter**2]
+    
+    end function
+    pure function rb_disk(mass, diameter, cg) result(rb)
+    type(rigid_body) :: rb
+    real(wp), intent(in) :: mass, diameter
+    real(wp), optional, intent(in) :: cg(3)
+        if(present(cg)) then
+            rb = rb_cylinder(mass, diameter, 0.0_wp, cg)
+        else
+            rb = rb_cylinder(mass, diameter, 0.0_wp)
+        end if
+    end function
+    pure function rb_rod(mass, length, cg) result(rb)
+    type(rigid_body) :: rb
+    real(wp), intent(in) :: mass, length
+    real(wp), optional, intent(in) :: cg(3)
+        if(present(cg)) then
+            rb = rb_cylinder(mass, 0.0_wp, length, cg)
+        else
+            rb = rb_cylinder(mass, 0.0_wp, length)
+        end if
+    end function
+    
+    pure function rb_get_mmoi_rot(rb, R, inv) result(I)
+    ! Get mass moment of inertia tensor for rigid body
+    ! given a the rotation matrix
+    class(rigid_body),intent(in) :: rb
+    real(wp), intent(in) :: R(3,3)
+    logical, intent(in), optional :: inv
+    real(wp) :: Rt(3,3), I(3,3)
+    integer :: n
+        if( present(inv) .and. inv) then
+            forall(n=1:3)
+                I(n,:) = (1/rb%mmoi(n)) * R(:,n)
+            end forall
+        else
+            forall(n=1:3)
+                I(n,:) = rb%mmoi(n) * R(:,n)
+            end forall
+        end if
+        I = matmul(R, I)
+    end function
+    
+    pure function rb_get_mmoi_state(rb, state, inv) result(I)
+    class(rigid_body),intent(in) :: rb
+    real(wp), intent(in) :: state(n_state)
+    logical, intent(in), optional :: inv
+    real(wp) :: I(3,3), R(3,3), q(4)
+        q = state(4:7)
+        R = rot(q)
+        if(present(inv)) then
+            I = rb_get_mmoi_rot(rb, R, inv)
+        else
+            I = rb_get_mmoi_rot(rb, R)
+        end if
+    end function
+    
+    pure function rb_get_state(rb, r_A, q, v_A, omega) result(state)
+    real(wp) :: state(n_state)
+    class(rigid_body),intent(in) :: rb
+    real(wp), intent(in) :: r_A(3), q(4), v_A(3), omega(3)
+    real(wp) :: R(3,3), I_C(3,3), p(3), L_A(3), c(3)
+    !tex: State vector composition
+    !$$\boldsymbol{y}:\begin{Bmatrix}\boldsymbol{r}_{A}=(x_{A},y_{A},z_{A})\\
+    !\boldsymbol{q}=(\boldsymbol{\hat{z}}\sin\left(\tfrac{\theta}{2}\right)|\cos\left(\tfrac{\theta}{2}\right))\\
+    !\boldsymbol{p}=m\left(\boldsymbol{v}_{A}+\boldsymbol{\omega}\times\boldsymbol{c}\right)\\
+    !\boldsymbol{L}_{A}={\rm I}_{C}\boldsymbol{\omega}+\boldsymbol{c}\times\boldsymbol{p}
+    !\end{Bmatrix}$$
+        R = rot(q)
+        I_C = rb_get_mmoi_rot(rb, R)
+        c = matmul(R, rb%cg)
+        p = rb%mass*(v_A + cross(omega,c))
+        L_A = matmul(I_C, omega) + cross(c,p)
+        state = [r_A, q, p, L_A]
+    end function
+    
+    pure subroutine rb_get_motion(rb, state, c, v_A, omega) 
+    ! Get motion variables from rigid body state y=(r_A,q,p,L_A)
+    class(rigid_body),intent(in) :: rb
+    real(wp), intent(in) :: state(n_state)
+    real(wp), intent(out) :: c(3), v_A(3), omega(3)
+    real(wp) :: R(3,3), I_inv(3,3), q(4), p(3), L_A(3)
+    !tex: Rigid body motion derived from momentum
+    !$$\begin{Bmatrix}\boldsymbol{v}_{A}=\tfrac{1}{m}\boldsymbol{p}-\boldsymbol{\omega}\times\boldsymbol{c}\\
+    !\boldsymbol{\omega}={\rm I}_{C}^{-1}\left(\boldsymbol{L}_{A}-\boldsymbol{c}\times\boldsymbol{p}\right)
+    !\end{Bmatrix}$$
+    
+        ! quaternion for orientation
+        q = state(4:7)                              
+        ! 3×3 rotation matrix from quaternion
+        R = rot(q)
+        ! relative position of cg
+        c = matmul(R, rb%cg)     
+        ! 3×3 inverse interia matrix at the CG 
+        ! from principal mass moment of inertia and rotation matrix
+        I_inv = rb_get_mmoi_rot(rb, R, .true.)
+        ! linear momentum vector
+        p = state(8:10)
+        ! angular momentum vector at the handle
+        L_A = state(11:13)
+        ! angular velocity from angular momentum
+        omega = matmul(I_inv, L_A - cross(c, p))
+        ! linear velocity of the handle from momentum
+        v_A = p / rb%mass - cross(omega, c)        
+    end subroutine
+    
+    pure function rb_get_state_rate(rb, state, force, torque_A) result(rate)
+    class(rigid_body),intent(in) :: rb
+    real(wp), intent(in) :: state(n_state)
+    real(wp), intent(in) :: force(3), torque_A(3)
+    real(wp) :: rate(n_state), p(3), L_A(3), c(3)
+    real(wp) :: r_A(3), q(4), v_A(3), omega(3)
+    real(wp) :: rp_A(3), qp(4), pp(3), Lp_A(3)
+    !tex: State vector rate of change
+    !$$\tfrac{{\rm d}}{{\rm d}t}\boldsymbol{y}:\begin{Bmatrix}\dot{\boldsymbol{r}}_{A}=\tfrac{1}{m}\boldsymbol{p}-\boldsymbol{\omega}\times\boldsymbol{c}\\
+    !\dot{\boldsymbol{q}}=\tfrac{1}{2}(\boldsymbol{q}_{s}\boldsymbol{\omega}+\boldsymbol{\omega}\times\boldsymbol{q}_{v}|-\boldsymbol{\omega}\cdot\boldsymbol{q}_{v})\\
+    !\dot{\boldsymbol{p}}=\boldsymbol{F}\\
+    !\dot{\boldsymbol{L}}_{A}=\boldsymbol{\tau}_{A}+\boldsymbol{p}\times\boldsymbol{v}_{A}
+    !\end{Bmatrix}$$
+        r_A = state(1:3)
+        q = state(4:7)
+        p = state(8:10)
+        L_A = state(11:13)
+        call rb%get_motion(state, c, v_A, omega)
+        rp_A = p/rb%mass - cross(omega,c)
+        qp = quat_product( [0.0_wp, omega/2], q)
+        pp = force
+        Lp_A = torque_A + cross(p, v_A)
+        rate = [rp_A, qp, pp, Lp_A]
+    end function
+    
+    pure function rb_get_kin_energy(rb, state) result(KE)
+    class(rigid_body),intent(in) :: rb
+    real(wp), intent(in) :: state(n_state)
+    real(wp) :: KE, c(3), v_A(3), omega(3), p(3), L_A(3)
+    !tex: Kinetic Energy 
+    !$$KE=\tfrac{1}{2}\left(\boldsymbol{v}_{A}\cdot\boldsymbol{p}+\boldsymbol{\omega}\cdot\boldsymbol{L}_{A}\right)$$
+        call rb%get_motion(state, c, v_A, omega)
+        p = state(8:10)
+        L_A = state(11:13)
+        KE = (dot_product(v_A,p) + dot_product(omega,L_A))/2
+    end function
+    
+    subroutine test_rb_sim()
+    use mod_show_matrix
+    type(rigid_body) :: rb
+    real(wp) :: r_A(3), q(4), v_A(3), omega(3), F(3), tau(3), c(3), I_C(3,3)
+    real(wp) :: h, KE
+    real(wp), dimension(n_state) :: state, rate, K0, K1, K2, K3, next
+    
+        real(wp), parameter :: dia = 1, ht=0.125, m = 1
+        real(wp), parameter :: cg(3) = (dia/2)*i_
+        
+        rb = rb_cylinder(m, dia, ht, cg)
+        print *, "RB MASS=", rb%mass
+        print *, "RB MMOI="
+        call show(rb%mmoi)
+        print *, "RB CG="
+        call show(rb%cg)
+        
+        r_A = o_
+        print *, "r_A="
+        call show(r_A)
+        q = quat(i_, 0.0_wp)
+        print *, "q="
+        call show(q)
+        omega = 10*k_
+        print *, "omega="
+        call show(omega)
+        v_A = cross(r_A + cg, omega)
+        print *, "v_A="
+        call show(v_A)  ! -5*j_
+        
+        state = rb_get_state(rb, r_A, q, v_A, omega)
+        print *, "state="
+        call show(state)
+        
+        I_C = rb%get_mmoi(state)
+        print *, "I_C="
+        call show(I_C)
+        
+        call rb%get_motion(state, c, v_A, omega)
+        print *, "c="
+        call show(c)
+        print *, "omega="
+        call show(omega)    ! 10*k_
+        print *, "v_A="
+        call show(v_A)      ! -5*j_
+        
+        KE = rb_get_kin_energy(rb, state)
+        
+        print *, "KE (state)=", KE, NEW_LINE('a')
+        tau = o_
+        F = o_
+        
+        h = 0.05_wp
+        K0 = rb_get_state_rate(rb, state, F, tau)
+        K1 = rb_get_state_rate(rb, state + (h/2)*K0, F, tau)
+        K2 = rb_get_state_rate(rb, state + (h/2)*K1, F, tau)
+        K3 = rb_get_state_rate(rb, state + h*K2, F, tau)
+        
+        rate = (K0 + 2*K1 + 2*K2 + K3)/6
+        print *, "rate="
+        call show(rate)
+        
+        next = state + h * rate
+        print *, "next="
+        call show(next)
+        
+        call rb_get_motion(rb, next, c, v_A, omega)
+        print *, "c="
+        call show(c)
+        print *, "omega="
+        call show(omega)
+        v_A = cross(r_A + cg, omega)
+        print *, "v_A="
+        call show(v_A)
+        
+        KE = rb_get_kin_energy(rb, next)
+        print *, "KE (next)=", KE, NEW_LINE('a')
+    
+    end subroutine
+    
+    end module

--- a/program.f90
+++ b/program.f90
@@ -7,9 +7,11 @@ implicit none
     
     !call test_mod_show()
     !call test_mod_vectors()
-    call test_array_inv()
+    !call test_array_inv()
     !call test_nasa_ode()
     !call test_nasa_quat()
+    
+    call test_rb()
     
     contains
     
@@ -129,6 +131,11 @@ implicit none
     subroutine test_nasa_quat()
     use mod_nasa_quat
     call quat_array_test()
+    end subroutine
+    
+    subroutine test_rb()
+    use mod_rigid_bodies
+    call test_rb_sim()
     end subroutine
     
     


### PR DESCRIPTION
Port `mod_nasa_ode` code from F77 to F95 by adding `intent` keywords, declaring `pure` procedures, and implementing an interface for function references instead of the `external` keyword.

Add test code for the `mod_rigid_bodies` that uses the `mod_nasa_ode` procedure `r8_rk45()` to integrate a spinning rigid body (disk) for about 10 seconds (sim time) with an angular resolution of about 5° per simulation step. 